### PR TITLE
Heredoc & Clear() Function

### DIFF
--- a/src/JS/JS.php
+++ b/src/JS/JS.php
@@ -87,6 +87,7 @@ class JS
      */
     public function generate(): string
     {
+        //Encode Final Object
         if ($this->compact) {
             $jsonEncode = '<?php echo json_encode(compact('.$this->reward.'),JSON_UNESCAPED_UNICODE);?>;';
         } elseif ($this->reward == 'vars') {
@@ -95,10 +96,23 @@ class JS
             $jsonEncode = '<?php echo json_encode(\Rmunate\Php2Js\Data\DataPhp2Js::'.$this->reward.'(),JSON_UNESCAPED_UNICODE); ?>;';
         }
 
-        return '<script id="'.$this->uniqueID.'">
-                    '.$this->license.'
-                    const '.$this->alias.' = '.$jsonEncode.'
-                    document.getElementById("'.$this->uniqueID.'").remove();
-                </script>';
+        $idElement = $this->uniqueID;
+        $license = $this->license;
+        $alias = $this->alias;
+
+        $script = <<<SCRIPT
+        <script id="$idElement">
+            $license
+            const $alias = $jsonEncode;
+            $alias.clear = function() {
+                Object.keys($alias).forEach(function(property) {
+                    delete $alias[property];
+                });
+            };
+            document.getElementById("$idElement").remove();
+        </script>
+        SCRIPT;
+
+        return $script;
     }
 }

--- a/src/Render.php
+++ b/src/Render.php
@@ -156,10 +156,10 @@ class Render extends BasePhp2Js
             }
 
             $jsonEncode = json_encode($this->varsJS, JSON_UNESCAPED_UNICODE);
-            $idElement = strtoupper(bin2hex(random_bytes(16)));;
+            $idElement = strtoupper(bin2hex(random_bytes(16)));
             $license = $this->license;
             $alias = $this->alias;
-            
+
             $script = <<<SCRIPT
             <script id="$idElement">
                 $license

--- a/src/Render.php
+++ b/src/Render.php
@@ -155,15 +155,23 @@ class Render extends BasePhp2Js
                 }
             }
 
-            $uniqueID = strtoupper(bin2hex(random_bytes(16)));
             $jsonEncode = json_encode($this->varsJS, JSON_UNESCAPED_UNICODE);
-
-            $script = '<script id="'.$uniqueID.'">
-                            '.$this->license.'
-                            const '.$this->alias.' = '.$jsonEncode.'
-                            
-                            document.getElementById("'.$uniqueID.'").remove();
-                        </script>';
+            $idElement = strtoupper(bin2hex(random_bytes(16)));;
+            $license = $this->license;
+            $alias = $this->alias;
+            
+            $script = <<<SCRIPT
+            <script id="$idElement">
+                $license
+                const $alias = $jsonEncode;
+                $alias.clear = function() {
+                    Object.keys($alias).forEach(function(property) {
+                        delete $alias[property];
+                    });
+                };
+                document.getElementById("$idElement").remove();
+            </script>
+            SCRIPT;
 
             /* Inject JS */
             $posicionCierreHead = strpos($html, '</head>');


### PR DESCRIPTION
In this enhancement, we have used the "heredoc" syntax (<<<SCRIPT ... SCRIPT) to assign the content of the script to the $script variable. This improves readability by allowing script content to be written on multiple lines without the need for concatenation.
Added the clear() function, so that it can be implemented at the end of the JS logic in order to empty the variables delivered by PHP