### PR TITLE
Add Function Clear

### DIFF
--- a/src/JS/JS.php
+++ b/src/JS/JS.php
@@ -96,22 +96,27 @@ class JS
             $jsonEncode = '<?php echo json_encode(\Rmunate\Php2Js\Data\DataPhp2Js::'.$this->reward.'(),JSON_UNESCAPED_UNICODE); ?>;';
         }
 
-        $idElement = $this->uniqueID;
-        $license = $this->license;
-        $alias = $this->alias;
-
-        $script =
-        '<script id="'.$idElement.'">
-            '.$license.'
-            const '.$alias.' = '.$jsonEncode.';
-            '.$alias.'.clear = function() {
-                Object.keys('.$alias.').forEach(function(property) {
-                    delete '.$alias.'[property];
-                });
-            };
-            document.getElementById("'.$idElement.'").remove();
-        </script>';
-
-        return $script;
+        return self::generateScriptTag($this->uniqueID, $this->license, $this->alias, $jsonEncode);
     }
+
+    /**
+     * @param mixed $idElement
+     * @param mixed $license
+     * @param mixed $alias
+     * 
+     * @return string
+     */
+    public static function generateScriptTag($id, $license, $alias, $json): string
+    {
+        return  '<script id="' . $id . '">'
+                    . $license . '
+                    const ' . $alias . ' = ' . $json . ';
+                    ' . $alias . '.clear = function() {
+                        Object.keys(' . $alias . ').forEach(function(property) {
+                            delete ' . $alias . '[property];
+                        });
+                    };
+                    document.getElementById("' . $id . '").remove();
+                </script>';
+    } 
 }

--- a/src/JS/JS.php
+++ b/src/JS/JS.php
@@ -104,11 +104,11 @@ class JS
         <script id="$idElement">
             $license
             const $alias = $jsonEncode;
-            $alias.clear = function() {
-                Object.keys($alias).forEach(function(property) {
-                    delete $alias[property];
-                });
-            };
+            // $alias.clear = function() {
+            //     Object.keys($alias).forEach(function(property) {
+            //         delete $alias[property];
+            //     });
+            // };
             document.getElementById("$idElement").remove();
         </script>
         SCRIPT;

--- a/src/JS/JS.php
+++ b/src/JS/JS.php
@@ -100,18 +100,17 @@ class JS
         $license = $this->license;
         $alias = $this->alias;
 
-        $script = <<<SCRIPT
-        <script id="$idElement">
-            $license
-            const $alias = $jsonEncode;
-            // $alias.clear = function() {
-            //     Object.keys($alias).forEach(function(property) {
-            //         delete $alias[property];
-            //     });
-            // };
-            document.getElementById("$idElement").remove();
-        </script>
-        SCRIPT;
+        $script =
+        '<script id="'.$idElement.'">
+            '.$license.'
+            const '.$alias.' = '.$jsonEncode.';
+            '.$alias.'.clear = function() {
+                Object.keys('.$alias.').forEach(function(property) {
+                    delete '.$alias.'[property];
+                });
+            };
+            document.getElementById("'.$idElement.'").remove();
+        </script>';
 
         return $script;
     }

--- a/src/JS/JS.php
+++ b/src/JS/JS.php
@@ -103,20 +103,20 @@ class JS
      * @param mixed $idElement
      * @param mixed $license
      * @param mixed $alias
-     * 
+     *
      * @return string
      */
     public static function generateScriptTag($id, $license, $alias, $json): string
     {
-        return  '<script id="' . $id . '">'
-                    . $license . '
-                    const ' . $alias . ' = ' . $json . ';
-                    ' . $alias . '.clear = function() {
-                        Object.keys(' . $alias . ').forEach(function(property) {
-                            delete ' . $alias . '[property];
+        return  '<script id="'.$id.'">'
+                    .$license.'
+                    const '.$alias.' = '.$json.';
+                    '.$alias.'.clear = function() {
+                        Object.keys('.$alias.').forEach(function(property) {
+                            delete '.$alias.'[property];
                         });
                     };
-                    document.getElementById("' . $id . '").remove();
+                    document.getElementById("'.$id.'").remove();
                 </script>';
-    } 
+    }
 }

--- a/src/Render.php
+++ b/src/Render.php
@@ -2,9 +2,10 @@
 
 namespace Rmunate\Php2Js;
 
-use Rmunate\Php2Js\Bases\BasePhp2Js;
+use Rmunate\Php2Js\JS\JS;
 use Rmunate\Php2Js\Data\DataPhp2Js;
 use Rmunate\Php2Js\License\License;
+use Rmunate\Php2Js\Bases\BasePhp2Js;
 
 class Render extends BasePhp2Js
 {
@@ -157,21 +158,8 @@ class Render extends BasePhp2Js
 
             $jsonEncode = json_encode($this->varsJS, JSON_UNESCAPED_UNICODE);
             $idElement = strtoupper(bin2hex(random_bytes(16)));;
-            $license = $this->license;
-            $alias = $this->alias;
-            
-            $script = <<<SCRIPT
-            <script id="$idElement">
-                $license
-                const $alias = $jsonEncode;
-                $alias.clear = function() {
-                    Object.keys($alias).forEach(function(property) {
-                        delete $alias[property];
-                    });
-                };
-                document.getElementById("$idElement").remove();
-            </script>
-            SCRIPT;
+
+            $script = JS::generateScriptTag($idElement, $this->license, $this->alias, $jsonEncode);
 
             /* Inject JS */
             $posicionCierreHead = strpos($html, '</head>');

--- a/src/Render.php
+++ b/src/Render.php
@@ -2,10 +2,10 @@
 
 namespace Rmunate\Php2Js;
 
-use Rmunate\Php2Js\JS\JS;
-use Rmunate\Php2Js\Data\DataPhp2Js;
-use Rmunate\Php2Js\License\License;
 use Rmunate\Php2Js\Bases\BasePhp2Js;
+use Rmunate\Php2Js\Data\DataPhp2Js;
+use Rmunate\Php2Js\JS\JS;
+use Rmunate\Php2Js\License\License;
 
 class Render extends BasePhp2Js
 {
@@ -157,7 +157,7 @@ class Render extends BasePhp2Js
             }
 
             $jsonEncode = json_encode($this->varsJS, JSON_UNESCAPED_UNICODE);
-            $idElement = strtoupper(bin2hex(random_bytes(16)));;
+            $idElement = strtoupper(bin2hex(random_bytes(16)));
 
             $script = JS::generateScriptTag($idElement, $this->license, $this->alias, $jsonEncode);
 


### PR DESCRIPTION
In this enhancement, we have changed the syntax of "heredoc" (<<<SCRIPT ... SCRIPT) to assign the script content to the $script variable. This improves readability by allowing script content to be written on multiple lines without the need for concatenation.
Added the clear() function, so that it can be implemented at the end of the JS logic in order to empty the variables delivered by PHP